### PR TITLE
[FEAT] #29 정산서 월 조회 api 추가

### DIFF
--- a/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementAddItemsAndCalculatePayoutsUseCase.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementAddItemsAndCalculatePayoutsUseCase.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.app.usecase;
+package com.modeunsa.boundedcontext.settlement.app;
 
 import com.modeunsa.boundedcontext.settlement.app.dto.SettlementOrderItemDto;
 import com.modeunsa.boundedcontext.settlement.domain.PayoutAmounts;

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementFacade.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementFacade.java
@@ -1,11 +1,9 @@
 package com.modeunsa.boundedcontext.settlement.app;
 
 import com.modeunsa.boundedcontext.settlement.app.dto.SettlementOrderItemDto;
-import com.modeunsa.boundedcontext.settlement.app.usecase.SettlementAddItemsAndCalculatePayoutsUseCase;
-import com.modeunsa.boundedcontext.settlement.app.usecase.SettlementSaveItemsUseCase;
-import com.modeunsa.boundedcontext.settlement.app.usecase.SettlementSyncMemberUseCase;
 import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementItem;
 import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementMember;
+import com.modeunsa.shared.settlement.dto.SettlementResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +15,7 @@ public class SettlementFacade {
   private final SettlementAddItemsAndCalculatePayoutsUseCase settlementProcessOrderUseCase;
   private final SettlementSaveItemsUseCase settlementSaveItemsUseCase;
   private final SettlementSyncMemberUseCase settlementSyncMemberUseCase;
+  private final SettlementSupport settlementSupport;
 
   @Transactional
   public SettlementMember syncMember(Long memberId, String memberRole) {
@@ -32,5 +31,10 @@ public class SettlementFacade {
   @Transactional
   public void saveItems(List<SettlementItem> items) {
     settlementSaveItemsUseCase.saveItems(items);
+  }
+
+  @Transactional
+  public SettlementResponseDto getSettlement(Long memberId, int year, int month) {
+    return settlementSupport.getSettlement(memberId, year, month);
   }
 }

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSaveItemsUseCase.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSaveItemsUseCase.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.app.usecase;
+package com.modeunsa.boundedcontext.settlement.app;
 
 import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementItem;
 import com.modeunsa.boundedcontext.settlement.out.SettlementItemRepository;

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSupport.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSupport.java
@@ -1,0 +1,79 @@
+package com.modeunsa.boundedcontext.settlement.app;
+
+import com.modeunsa.boundedcontext.settlement.domain.entity.Settlement;
+import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementItem;
+import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementMember;
+import com.modeunsa.boundedcontext.settlement.domain.policy.SettlementPolicy;
+import com.modeunsa.boundedcontext.settlement.out.SettlementMemberRepository;
+import com.modeunsa.boundedcontext.settlement.out.SettlementRepository;
+import com.modeunsa.global.exception.GeneralException;
+import com.modeunsa.global.status.ErrorStatus;
+import com.modeunsa.shared.settlement.dto.SettlementItemResponseDto;
+import com.modeunsa.shared.settlement.dto.SettlementResponseDto;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementSupport {
+
+  private final SettlementRepository settlementRepository;
+  private final SettlementMemberRepository settlementMemberRepository;
+
+  public SettlementResponseDto getSettlement(Long sellerMemberId, int year, int month) {
+    // 1. 정산서를 불러온다.
+    Settlement settlement =
+        settlementRepository
+            .findBySellerMemberIdAndSettlementYearAndSettlementMonth(sellerMemberId, year, month)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.SETTLEMENT_NOT_FOUND));
+
+    SettlementMember systemMember =
+        settlementMemberRepository
+            .findByName(SettlementPolicy.SYSTEM)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.SETTLEMENT_MEMBER_NOT_FOUND));
+
+    Settlement feeSettlement =
+        settlementRepository
+            .findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+                systemMember.getId(), year, month)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.SETTLEMENT_NOT_FOUND));
+
+    // 수수료를 map으로 저장
+    Map<Long, BigDecimal> feeMap =
+        feeSettlement.getItems().stream()
+            .collect(Collectors.toMap(SettlementItem::getOrderItemId, SettlementItem::getAmount));
+
+    // 2. 정산금, 수수료 두개를 불러와서 하나의 dto에 합산
+    SettlementResponseDto settlementResponseDto =
+        SettlementResponseDto.create(
+            settlement.getId(),
+            feeSettlement.getAmount(),
+            settlement.getAmount(),
+            settlement.getPayoutAt());
+
+    settlement
+        .getItems()
+        .forEach(
+            item -> {
+              BigDecimal feeAmount = feeMap.getOrDefault(item.getOrderItemId(), BigDecimal.ZERO);
+              BigDecimal totalSales = item.getAmount().add(feeAmount);
+
+              settlementResponseDto.addItem(
+                  SettlementItemResponseDto.builder()
+                      .id(item.getId())
+                      .orderItemId(item.getOrderItemId())
+                      .buyerMemberId(item.getBuyerMemberId())
+                      .sellerMemberId(item.getSellerMemberId())
+                      .amount(item.getAmount())
+                      .feeAmount(feeAmount)
+                      .totalSalesAmount(totalSales)
+                      .paymentAt(item.getPaymentAt())
+                      .build());
+            });
+
+    return settlementResponseDto;
+  }
+}

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSyncMemberUseCase.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/app/SettlementSyncMemberUseCase.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.app.usecase;
+package com.modeunsa.boundedcontext.settlement.app;
 
 import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementMember;
 import com.modeunsa.boundedcontext.settlement.out.SettlementMemberRepository;

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/domain/entity/Settlement.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/domain/entity/Settlement.java
@@ -86,8 +86,4 @@ public class Settlement extends GeneratedIdAndAuditedEntity {
   public void completePayout() {
     this.payoutAt = LocalDateTime.now();
   }
-
-  public boolean isCompletedPayout() {
-    return this.payoutAt != null;
-  }
 }

--- a/src/main/java/com/modeunsa/boundedcontext/settlement/in/ApiV1SettlementController.java
+++ b/src/main/java/com/modeunsa/boundedcontext/settlement/in/ApiV1SettlementController.java
@@ -1,0 +1,37 @@
+package com.modeunsa.boundedcontext.settlement.in;
+
+import com.modeunsa.boundedcontext.settlement.app.SettlementFacade;
+import com.modeunsa.global.response.ApiResponse;
+import com.modeunsa.global.status.SuccessStatus;
+import com.modeunsa.shared.settlement.dto.SettlementResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Settlement", description = "정산 도메인 API")
+@RestController
+@RequestMapping("/api/v1/settlements")
+@RequiredArgsConstructor
+public class ApiV1SettlementController {
+  private final SettlementFacade settlementFacade;
+
+  @Operation(summary = "월별 정산서 조회", description = "원하는 월의 정산서를 조회합니다.")
+  @GetMapping("/{year}/{month}")
+  public ResponseEntity<ApiResponse> getSettlement(
+      @PathVariable int year, @PathVariable @Min(1) @Max(12) int month) {
+    // TODO: security 추가시 sellerId 변경
+    Long sellerId = 7L;
+
+    SettlementResponseDto settlementResponseDto =
+        settlementFacade.getSettlement(sellerId, year, month);
+
+    return ApiResponse.onSuccess(SuccessStatus.CREATED, settlementResponseDto);
+  }
+}

--- a/src/main/java/com/modeunsa/shared/settlement/dto/SettlementItemResponseDto.java
+++ b/src/main/java/com/modeunsa/shared/settlement/dto/SettlementItemResponseDto.java
@@ -1,0 +1,19 @@
+package com.modeunsa.shared.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SettlementItemResponseDto {
+  private Long id;
+  private Long orderItemId;
+  private Long buyerMemberId;
+  private Long sellerMemberId;
+  @Builder.Default private BigDecimal totalSalesAmount = BigDecimal.ZERO;
+  @Builder.Default private BigDecimal feeAmount = BigDecimal.ZERO;
+  @Builder.Default private BigDecimal amount = BigDecimal.ZERO;
+  private LocalDateTime paymentAt;
+}

--- a/src/main/java/com/modeunsa/shared/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/modeunsa/shared/settlement/dto/SettlementResponseDto.java
@@ -1,0 +1,39 @@
+package com.modeunsa.shared.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SettlementResponseDto {
+  private Long id;
+  @Builder.Default private BigDecimal totalSalesAmount = BigDecimal.ZERO;
+  @Builder.Default private BigDecimal feeAmount = BigDecimal.ZERO;
+  @Builder.Default private BigDecimal amount = BigDecimal.ZERO;
+  private LocalDateTime payoutAt;
+  @Builder.Default private List<SettlementItemResponseDto> items = new ArrayList<>();
+
+  public static SettlementResponseDto create(
+      Long id, BigDecimal feeAmount, BigDecimal amount, LocalDateTime payoutAt) {
+    return SettlementResponseDto.builder()
+        .id(id)
+        .totalSalesAmount(feeAmount.add(amount))
+        .feeAmount(feeAmount)
+        .amount(amount)
+        .payoutAt(payoutAt)
+        .build();
+  }
+
+  public void addItem(SettlementItemResponseDto settlementItemResponseDto) {
+    items.add(settlementItemResponseDto);
+  }
+}

--- a/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementAddItemsAndCalculatePayoutsUseCaseTest.java
+++ b/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementAddItemsAndCalculatePayoutsUseCaseTest.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.app.usecase;
+package com.modeunsa.boundedcontext.settlement.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementSaveItemsUseCaseTest.java
+++ b/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementSaveItemsUseCaseTest.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.app.usecase;
+package com.modeunsa.boundedcontext.settlement.app;
 
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementSupportTest.java
+++ b/src/test/java/com/modeunsa/boundedcontext/settlement/app/SettlementSupportTest.java
@@ -1,0 +1,200 @@
+package com.modeunsa.boundedcontext.settlement.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.modeunsa.boundedcontext.settlement.domain.entity.Settlement;
+import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementMember;
+import com.modeunsa.boundedcontext.settlement.domain.policy.SettlementPolicy;
+import com.modeunsa.boundedcontext.settlement.domain.types.SettlementEventType;
+import com.modeunsa.boundedcontext.settlement.out.SettlementMemberRepository;
+import com.modeunsa.boundedcontext.settlement.out.SettlementRepository;
+import com.modeunsa.global.exception.GeneralException;
+import com.modeunsa.shared.settlement.dto.SettlementResponseDto;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SettlementSupport 테스트")
+class SettlementSupportTest {
+
+  @Mock private SettlementRepository settlementRepository;
+  @Mock private SettlementMemberRepository settlementMemberRepository;
+
+  @InjectMocks private SettlementSupport settlementSupport;
+
+  private static final Long SELLER_ID = 7L;
+  private static final Long SYSTEM_ID = 1L;
+  private static final Long BUYER_ID = 4L;
+  private static final int YEAR = 2025;
+  private static final int MONTH = 12;
+
+  private Settlement sellerSettlement;
+  private Settlement feeSettlement;
+  private SettlementMember systemMember;
+
+  @BeforeEach
+  void setUp() {
+    SettlementPolicy.FEE_RATE = new BigDecimal("0.1");
+
+    sellerSettlement = Settlement.create(SELLER_ID, YEAR, MONTH);
+    feeSettlement = Settlement.create(SYSTEM_ID, YEAR, MONTH);
+    systemMember = SettlementMember.create(SYSTEM_ID, "SYSTEM");
+
+    // 판매자 정산 아이템 추가 (판매대금)
+    sellerSettlement.addItem(
+        1001L,
+        BUYER_ID,
+        SELLER_ID,
+        new BigDecimal("9000"),
+        SettlementEventType.SETTLEMENT_PRODUCT_SALES_AMOUNT,
+        LocalDateTime.now());
+    sellerSettlement.addItem(
+        1002L,
+        BUYER_ID,
+        SELLER_ID,
+        new BigDecimal("22500"),
+        SettlementEventType.SETTLEMENT_PRODUCT_SALES_AMOUNT,
+        LocalDateTime.now());
+
+    // SYSTEM 정산 아이템 추가 (수수료)
+    feeSettlement.addItem(
+        1001L,
+        BUYER_ID,
+        SYSTEM_ID,
+        new BigDecimal("1000"),
+        SettlementEventType.SETTLEMENT_PRODUCT_SALES_FEE,
+        LocalDateTime.now());
+    feeSettlement.addItem(
+        1002L,
+        BUYER_ID,
+        SYSTEM_ID,
+        new BigDecimal("2500"),
+        SettlementEventType.SETTLEMENT_PRODUCT_SALES_FEE,
+        LocalDateTime.now());
+  }
+
+  @Test
+  @DisplayName("정산 조회 시 판매대금과 수수료가 합산된 DTO 반환")
+  void getSettlement_returns_combinedDto() {
+    // given
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SELLER_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(sellerSettlement));
+
+    when(settlementMemberRepository.findByName(SettlementPolicy.SYSTEM))
+        .thenReturn(Optional.of(systemMember));
+
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SYSTEM_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(feeSettlement));
+
+    // when
+    SettlementResponseDto result = settlementSupport.getSettlement(SELLER_ID, YEAR, MONTH);
+
+    // then
+    assertThat(result.getId()).isEqualTo(sellerSettlement.getId());
+    assertThat(result.getAmount()).isEqualByComparingTo(new BigDecimal("31500")); // 9000 + 22500
+    assertThat(result.getFeeAmount()).isEqualByComparingTo(new BigDecimal("3500")); // 1000 + 2500
+    assertThat(result.getTotalSalesAmount())
+        .isEqualByComparingTo(new BigDecimal("35000")); // 31500 + 3500
+  }
+
+  @Test
+  @DisplayName("정산 아이템별로 판매대금, 수수료, 총액이 정확히 계산됨")
+  void getSettlement_calculatesItemAmounts_correctly() {
+    // given
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SELLER_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(sellerSettlement));
+
+    when(settlementMemberRepository.findByName(SettlementPolicy.SYSTEM))
+        .thenReturn(Optional.of(systemMember));
+
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SYSTEM_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(feeSettlement));
+
+    // when
+    SettlementResponseDto result = settlementSupport.getSettlement(SELLER_ID, YEAR, MONTH);
+
+    // then
+    var item1 =
+        result.getItems().stream()
+            .filter(i -> i.getOrderItemId().equals(1001L))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(item1.getAmount()).isEqualByComparingTo(new BigDecimal("9000"));
+    assertThat(item1.getFeeAmount()).isEqualByComparingTo(new BigDecimal("1000"));
+    assertThat(item1.getTotalSalesAmount()).isEqualByComparingTo(new BigDecimal("10000"));
+
+    var item2 =
+        result.getItems().stream()
+            .filter(i -> i.getOrderItemId().equals(1002L))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(item2.getAmount()).isEqualByComparingTo(new BigDecimal("22500"));
+    assertThat(item2.getFeeAmount()).isEqualByComparingTo(new BigDecimal("2500"));
+    assertThat(item2.getTotalSalesAmount()).isEqualByComparingTo(new BigDecimal("25000"));
+  }
+
+  @Test
+  @DisplayName("판매자 정산이 없으면 예외 발생")
+  void getSettlement_throws_whenSellerSettlementNotFound() {
+    // given
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SELLER_ID, YEAR, MONTH))
+        .thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> settlementSupport.getSettlement(SELLER_ID, YEAR, MONTH))
+        .isInstanceOf(GeneralException.class);
+  }
+
+  @Test
+  @DisplayName("시스템 멤버가 없으면 예외 발생")
+  void getSettlement_throws_whenSystemMemberNotFound() {
+    // given
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SELLER_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(sellerSettlement));
+
+    when(settlementMemberRepository.findByName(SettlementPolicy.SYSTEM))
+        .thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> settlementSupport.getSettlement(SELLER_ID, YEAR, MONTH))
+        .isInstanceOf(GeneralException.class);
+  }
+
+  @Test
+  @DisplayName("수수료 정산이 없으면 예외 발생")
+  void getSettlement_throws_whenFeeSettlementNotFound() {
+    // given
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SELLER_ID, YEAR, MONTH))
+        .thenReturn(Optional.of(sellerSettlement));
+
+    when(settlementMemberRepository.findByName(SettlementPolicy.SYSTEM))
+        .thenReturn(Optional.of(systemMember));
+
+    when(settlementRepository.findBySellerMemberIdAndSettlementYearAndSettlementMonth(
+            SYSTEM_ID, YEAR, MONTH))
+        .thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> settlementSupport.getSettlement(SELLER_ID, YEAR, MONTH))
+        .isInstanceOf(GeneralException.class);
+  }
+}

--- a/src/test/java/com/modeunsa/boundedcontext/settlement/in/SettlementCollectItemsAndCalculatePayoutsStepConfigTest.java
+++ b/src/test/java/com/modeunsa/boundedcontext/settlement/in/SettlementCollectItemsAndCalculatePayoutsStepConfigTest.java
@@ -1,4 +1,4 @@
-package com.modeunsa.boundedcontext.settlement.in.batch;
+package com.modeunsa.boundedcontext.settlement.in;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,7 +13,6 @@ import com.modeunsa.boundedcontext.settlement.app.dto.SettlementOrderItemDto;
 import com.modeunsa.boundedcontext.settlement.domain.entity.Settlement;
 import com.modeunsa.boundedcontext.settlement.domain.entity.SettlementItem;
 import com.modeunsa.boundedcontext.settlement.domain.types.SettlementEventType;
-import com.modeunsa.boundedcontext.settlement.in.OrderApiClient;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)


## PR 작성 전 체크 리스트 (PR 생성시 해당 항목은 삭제 후 올려주세요!)

- merge 브랜치 확인할 것. **main으로 보내면 안 됨 :x:**
- PR 제목: `[태그] #{이슈 번호}: {내용}`
    - 예: [FEAT] #20: 로그인 기능 구현

`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

-->

## #⃣ 연관된 이슈
> #29

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 수수료 정산서와 판매자 정산금 정산서의 합을 계산해서 최종 월 정산서로 보여줍니다.
- 총 판매 대금, 수수료, 정산금으로 세가지로 정산서에 기입해줍니다.
- 정산서내에 정산 상품들을 보여줍니다. 상품별로 수수료와 정산금이 어떻게 구성되어있는지 알 수 있습니다.


### Test
> - 어떻게 검증했는지
> - 실행 방법 / 확인 결과

### 📸 스크린샷 (선택)
<img width="1418" height="917" alt="image" src="https://github.com/user-attachments/assets/9a24e557-d384-43e6-9175-05640c99dea4" />