### PR TITLE
[Feat] #299 개발 환경 전용 로그인 API에 쿠키 인증 지원

### DIFF
--- a/src/main/java/com/modeunsa/boundedcontext/auth/in/controller/ApiV1DevAuthController.java
+++ b/src/main/java/com/modeunsa/boundedcontext/auth/in/controller/ApiV1DevAuthController.java
@@ -4,15 +4,18 @@ import com.modeunsa.boundedcontext.auth.app.facade.AuthFacade;
 import com.modeunsa.boundedcontext.member.app.support.MemberSupport;
 import com.modeunsa.boundedcontext.member.domain.entity.Member;
 import com.modeunsa.boundedcontext.member.out.repository.MemberRepository;
+import com.modeunsa.global.config.CookieProperties;
 import com.modeunsa.global.exception.GeneralException;
 import com.modeunsa.global.status.ErrorStatus;
 import com.modeunsa.shared.auth.dto.JwtTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +30,7 @@ public class ApiV1DevAuthController {
   private final MemberRepository memberRepository;
   private final MemberSupport memberSupport;
   private final AuthFacade authFacade;
+  private final CookieProperties cookieProperties;
 
   @Operation(
       summary = "개발용 프리패스 로그인",
@@ -45,20 +49,28 @@ public class ApiV1DevAuthController {
     Long sellerId = memberSupport.getSellerIdByMemberId(memberId);
     JwtTokenResponse tokenResponse = authFacade.login(member.getId(), member.getRole(), sellerId);
 
-    // Access Token 쿠키
-    Cookie accessCookie = new Cookie("accessToken", tokenResponse.accessToken());
-    accessCookie.setPath("/");
-    accessCookie.setHttpOnly(true);
-    accessCookie.setMaxAge((int) (tokenResponse.accessTokenExpiresIn() / 1000L));
-    response.addCookie(accessCookie);
-
-    // Refresh Token 쿠키
-    Cookie refreshCookie = new Cookie("refreshToken", tokenResponse.refreshToken());
-    refreshCookie.setPath("/");
-    refreshCookie.setHttpOnly(true);
-    refreshCookie.setMaxAge((int) (tokenResponse.refreshTokenExpiresIn() / 1000L));
-    response.addCookie(refreshCookie);
+    addCookie(
+        response, "accessToken", tokenResponse.accessToken(), tokenResponse.accessTokenExpiresIn());
+    addCookie(
+        response,
+        "refreshToken",
+        tokenResponse.refreshToken(),
+        tokenResponse.refreshTokenExpiresIn());
 
     return tokenResponse;
+  }
+
+  private void addCookie(
+      HttpServletResponse response, String name, String value, long expiresInMillis) {
+    ResponseCookie cookie =
+        ResponseCookie.from(name, value)
+            .path(cookieProperties.getPath())
+            .httpOnly(cookieProperties.isHttpOnly())
+            .secure(cookieProperties.isSecure())
+            .sameSite(cookieProperties.getSameSite())
+            .maxAge(Duration.ofMillis(expiresInMillis))
+            .build();
+
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

- close #299 

## 📝 작업 내용

- 작업한 API는 OAuth 인증 과정 없이 특정 memberId만으로 즉시 로그인을 시뮬레이션할 수 있는 개발용 API입니다.
- 기존에는 토큰만 생성하도록 구현되어 있었는데, 프론트와 연동함에 따라 쿠키로 인증하는 구조로 변환되어 이에 맞게 수정하였습니다.
- 생성된 토큰을 HTTP 응답 헤더뿐만 아니라 **쿠키(accessToken, refreshToken)** 에도 구워주도록 구현했습니다.

### Test
- API 호출 테스트
  - POST /api/v1/auths/dev/login?memberId=3 호출 시 응답 본문에 토큰 반환 확인 완료
  - 상품/회원 API 호출 응답 확인 완료

### 📸 스크린샷 (선택)
- POST /api/v1/auths/dev/login?memberId=5

<img width="1049" height="1067" alt="스크린샷 2026-02-07 040638" src="https://github.com/user-attachments/assets/bf9cd24b-af44-4d56-9431-e4a2bf37b6f1" />

- GET /api/v1/members/me/basic-info

<img width="1044" height="998" alt="스크린샷 2026-02-07 040726" src="https://github.com/user-attachments/assets/6b07187c-ca3a-4f3a-a025-1576c5cc4d87" />

- GET /api/v1/products?category=OUTER&page=1&size=1

<img width="1030" height="283" alt="image" src="https://github.com/user-attachments/assets/77bf01bc-ce5e-46ae-95ca-47ab0f3e6c8e" />



## 💬 리뷰 참고 사항
- 상품과 회원에만 테스트해보았기에 다른 모듈에서도 적용이 되는지는 테스트 진행해 보아야합니다.
- 타 모듈에서 이 API를 활용하여 테스트를 진행해야 한다면, 진행해보시고 오류가 난다면 말씀 부탁드립니다.