### PR TITLE
[Fix] #632 common 모듈에 SwaggerConfig 추가

### DIFF
--- a/common/src/main/java/com/modeunsa/global/config/SwaggerConfig.java
+++ b/common/src/main/java/com/modeunsa/global/config/SwaggerConfig.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile("!test")
 @Configuration
 public class SwaggerConfig {
 
-  @Value("${custom.swagger.serverUrl}")
+  @Value("${custom.swagger.serverUrl:http://localhost}")
   private String serverUrl;
 
   @Value("${custom.swagger.description}")

--- a/common/src/main/resources/application-test.yml
+++ b/common/src/main/resources/application-test.yml
@@ -21,3 +21,7 @@ spring:
 
 internal:
   api-key: test-internal-key
+
+custom:
+  swagger:
+    serverUrl: http://localhost


### PR DESCRIPTION
## #⃣ 연관된 이슈

- close #632 

## 📝 작업 내용

- swagger의 cors 에러 해결을 위해 common 모듈에 SwaggerConfig 추가

### Test
- swagger에서 /api/v1/auths/dev/login 테스트

### 📸 스크린샷
<img width="706" height="1595" alt="image" src="https://github.com/user-attachments/assets/9a34caad-a53f-4217-9267-d7479da876d6" />

<!--
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->