### PR TITLE
[feat] #677: 결제 최종 실패 시 재고 복구 이벤트 발행 추가

### DIFF
--- a/order-service/src/main/java/com/modeunsa/boundedcontext/order/app/OrderFacade.java
+++ b/order-service/src/main/java/com/modeunsa/boundedcontext/order/app/OrderFacade.java
@@ -43,6 +43,7 @@ public class OrderFacade {
   private final OrderAddOrderDeliveryInfoUseCase orderAddOrderDeliveryInfoUseCase;
   private final OrderConfirmOrderCancellationUseCase orderConfirmOrderCancellationUseCase;
   private final OrderApproveOrderUseCase orderApproveOrderUseCase;
+  private final OrderRejectOrderUseCase orderRejectOrderUseCase;
 
   // 장바구니 아이템 생성
   @Transactional
@@ -122,8 +123,7 @@ public class OrderFacade {
 
   @Transactional
   public void rejectOrder(PaymentDto payment) {
-    Order order = orderSupport.findByOrderId(payment.orderId());
-    order.reject();
+    orderRejectOrderUseCase.rejectOrder(payment);
   }
 
   @Transactional

--- a/order-service/src/main/java/com/modeunsa/boundedcontext/order/app/OrderRejectOrderUseCase.java
+++ b/order-service/src/main/java/com/modeunsa/boundedcontext/order/app/OrderRejectOrderUseCase.java
@@ -1,0 +1,33 @@
+package com.modeunsa.boundedcontext.order.app;
+
+import com.modeunsa.boundedcontext.order.domain.Order;
+import com.modeunsa.boundedcontext.order.domain.OrderMapper;
+import com.modeunsa.boundedcontext.order.out.OrderRepository;
+import com.modeunsa.global.eventpublisher.EventPublisher;
+import com.modeunsa.global.exception.GeneralException;
+import com.modeunsa.global.status.ErrorStatus;
+import com.modeunsa.shared.order.event.OrderCancellationConfirmedEvent;
+import com.modeunsa.shared.payment.dto.PaymentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderRejectOrderUseCase {
+  private final OrderRepository orderRepository;
+  private final OrderMapper orderMapper;
+  private final EventPublisher eventPublisher;
+
+  public void rejectOrder(PaymentDto payment) {
+    Order order =
+        orderRepository
+            .findById(payment.orderId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus.ORDER_NOT_FOUND));
+
+    order.reject();
+
+    eventPublisher.publish(
+        new OrderCancellationConfirmedEvent(
+            order.getId(), orderMapper.toOrderItemDto(order.getOrderItems())));
+  }
+}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

## #⃣ 연관된 이슈

> close #677 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> ### How
> - 구현 방법
> - 설계 포인트 / 기술 선택 (선택)
- 결제 기한동안 결제가 되지 못해 최종실패 한 경우, 주문취소가 될 때 재고도 복구 가능하도록 수정

### Test
> - 어떻게 검증했는지
> - 실행 방법 / 확인 결과

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?