### PR TITLE
[FEAT] #589: member-service 트랜잭션 아웃박스 패턴 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ src/main/generated/
 
 # plugins
 debezium-envelope-wrapper-*.jar
+# oh-my-claudecode operational state
+.omc/

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/app/outbox/MemberOutboxPoller.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/app/outbox/MemberOutboxPoller.java
@@ -1,0 +1,53 @@
+package com.modeunsa.boundedcontext.member.app.outbox;
+
+import com.modeunsa.boundedcontext.member.out.MemberOutboxReader;
+import com.modeunsa.boundedcontext.member.out.MemberOutboxStore;
+import com.modeunsa.global.kafka.outbox.OutboxPollerRunner;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "outbox.poller.enabled", havingValue = "true", matchIfMissing = true)
+public class MemberOutboxPoller {
+
+  private final OutboxPollerRunner outboxPollerRunner;
+  private final MemberOutboxReader memberOutboxReader;
+  private final MemberOutboxStore memberOutboxStore;
+
+  @Value("${outbox.poller.batch-size:100}")
+  private int batchSize;
+
+  @Value("${outbox.poller.max-retry:5}")
+  private int maxRetry;
+
+  @Value("${outbox.poller.retention-days:7}")
+  private int retentionDays;
+
+  @Value("${outbox.timeoutMs:10000}")
+  private int timeoutMs;
+
+  @Value("${outbox.cleanup.batch-size:500}")
+  private int cleanupBatchSize;
+
+  @Scheduled(fixedDelayString = "${outbox.poller.interval-ms:5000}")
+  @Transactional
+  public void poll() {
+    outboxPollerRunner.runPolling(
+        memberOutboxReader, memberOutboxStore, batchSize, maxRetry, timeoutMs);
+  }
+
+  @Scheduled(cron = "${outbox.cleanup.cron:0 0 3 * * *}")
+  @Transactional
+  public void cleanupOldEvents() {
+    LocalDateTime before = LocalDateTime.now().minusDays(retentionDays);
+    outboxPollerRunner.runCleanup(memberOutboxReader, memberOutboxStore, before, cleanupBatchSize);
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/app/outbox/MemberOutboxPublisher.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/app/outbox/MemberOutboxPublisher.java
@@ -1,0 +1,51 @@
+package com.modeunsa.boundedcontext.member.app.outbox;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.boundedcontext.member.out.MemberOutboxStore;
+import com.modeunsa.global.eventpublisher.topic.KafkaPublishTarget;
+import com.modeunsa.global.eventpublisher.topic.KafkaResolver;
+import com.modeunsa.global.json.JsonConverter;
+import com.modeunsa.global.kafka.outbox.OutboxPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.event-publisher.type", havingValue = "outbox")
+public class MemberOutboxPublisher implements OutboxPublisher {
+
+  private final MemberOutboxStore memberOutboxStore;
+  private final JsonConverter jsonConverter;
+  private final KafkaResolver kafkaResolver;
+
+  @Override
+  @Transactional(propagation = Propagation.MANDATORY)
+  public void saveToOutbox(Object event) {
+
+    KafkaPublishTarget target = kafkaResolver.resolve(event);
+    String payload = jsonConverter.serialize(event);
+    MemberOutboxEvent outboxEvent =
+        MemberOutboxEvent.create(
+            target.aggregateType(),
+            target.aggregateId(),
+            event.getClass().getSimpleName(),
+            target.topic(),
+            payload,
+            target.traceId());
+
+    try {
+      memberOutboxStore.store(outboxEvent);
+    } catch (DataIntegrityViolationException e) {
+      log.warn(
+          "Outbox event already exists for aggregateId: {}, eventType: {}",
+          outboxEvent.getAggregateId(),
+          outboxEvent.getEventType());
+    }
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/domain/entity/MemberOutboxEvent.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/domain/entity/MemberOutboxEvent.java
@@ -1,0 +1,90 @@
+package com.modeunsa.boundedcontext.member.domain.entity;
+
+import com.modeunsa.global.jpa.converter.EncryptedStringConverter;
+import com.modeunsa.global.jpa.entity.AuditedEntity;
+import com.modeunsa.global.kafka.outbox.OutboxEventView;
+import com.modeunsa.global.kafka.outbox.OutboxStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "member_outbox_event",
+    uniqueConstraints = {@UniqueConstraint(columnNames = "event_id")})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberOutboxEvent extends AuditedEntity implements OutboxEventView {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String aggregateType;
+
+  @Column(nullable = false)
+  private String aggregateId;
+
+  @Column(nullable = false, length = 100)
+  private String eventType;
+
+  @Column(nullable = false, length = 100)
+  private String topic;
+
+  // 회원 이벤트 payload에는 이름/전화번호 등 PII가 포함되므로 엔티티 필드와 동일하게 저장 시 암호화한다
+  @Lob
+  @Convert(converter = EncryptedStringConverter.class)
+  @Column(nullable = false)
+  private String payload;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private OutboxStatus status = OutboxStatus.PENDING;
+
+  private LocalDateTime sentAt;
+
+  private int retryCount;
+
+  private String lastErrorMessage;
+
+  private String eventId;
+
+  private String traceId;
+
+  public static MemberOutboxEvent create(
+      String aggregateType,
+      String aggregateId,
+      String eventType,
+      String topic,
+      String payload,
+      String traceId) {
+    return MemberOutboxEvent.builder()
+        .aggregateType(aggregateType)
+        .aggregateId(aggregateId)
+        .eventType(eventType)
+        .topic(topic)
+        .payload(payload)
+        .eventId(UUID.randomUUID().toString())
+        .traceId(traceId)
+        .build();
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/MemberOutboxReader.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/MemberOutboxReader.java
@@ -1,0 +1,15 @@
+package com.modeunsa.boundedcontext.member.out;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.global.kafka.outbox.OutboxReader;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberOutboxReader extends OutboxReader {
+  @Override
+  List<MemberOutboxEvent> findPendingEventsWithLock(Pageable pageable);
+
+  @Override
+  List<Long> findDeleteTargetIds(LocalDateTime before, Pageable pageable);
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/MemberOutboxStore.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/MemberOutboxStore.java
@@ -1,0 +1,21 @@
+package com.modeunsa.boundedcontext.member.out;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.global.kafka.outbox.OutboxStore;
+import java.util.List;
+
+public interface MemberOutboxStore extends OutboxStore {
+  MemberOutboxEvent store(MemberOutboxEvent newMemberOutboxEvent);
+
+  @Override
+  long deleteAlreadySentEventByIds(List<Long> ids);
+
+  @Override
+  void markProcessing(Long id);
+
+  @Override
+  void markSent(Long id);
+
+  @Override
+  void markFailed(Long id, String errorMessage, int maxRetry);
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/JpaMemberOutboxReader.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/JpaMemberOutboxReader.java
@@ -1,0 +1,26 @@
+package com.modeunsa.boundedcontext.member.out.persistence.outbox;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.boundedcontext.member.out.MemberOutboxReader;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaMemberOutboxReader implements MemberOutboxReader {
+
+  private final MemberOutboxQueryRepository queryRepository;
+
+  @Override
+  public List<MemberOutboxEvent> findPendingEventsWithLock(Pageable pageable) {
+    return queryRepository.findPendingEventsWithLock(pageable);
+  }
+
+  @Override
+  public List<Long> findDeleteTargetIds(LocalDateTime before, Pageable pageable) {
+    return queryRepository.findDeleteTargetIds(before, pageable);
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/JpaMemberOutboxStore.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/JpaMemberOutboxStore.java
@@ -1,0 +1,41 @@
+package com.modeunsa.boundedcontext.member.out.persistence.outbox;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.boundedcontext.member.out.MemberOutboxStore;
+import com.modeunsa.global.kafka.outbox.OutboxStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaMemberOutboxStore implements MemberOutboxStore {
+
+  private final MemberOutboxCommandRepository memberOutboxCommandRepository;
+
+  @Override
+  public MemberOutboxEvent store(MemberOutboxEvent newMemberOutboxEvent) {
+    return memberOutboxCommandRepository.store(newMemberOutboxEvent);
+  }
+
+  @Override
+  public long deleteAlreadySentEventByIds(List<Long> ids) {
+    return memberOutboxCommandRepository.deleteAlreadySentEventBefore(ids);
+  }
+
+  @Override
+  public void markProcessing(Long id) {
+    memberOutboxCommandRepository.updateStatus(id, OutboxStatus.PROCESSING, LocalDateTime.now());
+  }
+
+  @Override
+  public void markSent(Long id) {
+    memberOutboxCommandRepository.markSent(id, OutboxStatus.SENT, LocalDateTime.now());
+  }
+
+  @Override
+  public void markFailed(Long id, String errorMessage, int maxRetry) {
+    memberOutboxCommandRepository.markFailed(id, errorMessage, LocalDateTime.now(), maxRetry);
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/MemberOutboxCommandRepository.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/MemberOutboxCommandRepository.java
@@ -1,0 +1,66 @@
+package com.modeunsa.boundedcontext.member.out.persistence.outbox;
+
+import static com.modeunsa.boundedcontext.member.domain.entity.QMemberOutboxEvent.memberOutboxEvent;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.global.kafka.outbox.OutboxStatus;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberOutboxCommandRepository {
+
+  private final EntityManager entityManager;
+
+  public MemberOutboxEvent store(MemberOutboxEvent event) {
+    entityManager.persist(event);
+    return event;
+  }
+
+  public long deleteAlreadySentEventBefore(List<Long> ids) {
+    return new JPADeleteClause(entityManager, memberOutboxEvent)
+        .where(memberOutboxEvent.id.in(ids))
+        .execute();
+  }
+
+  public void updateStatus(Long id, OutboxStatus status, LocalDateTime now) {
+    new JPAUpdateClause(entityManager, memberOutboxEvent)
+        .set(memberOutboxEvent.status, status)
+        .set(memberOutboxEvent.updatedAt, now)
+        .where(memberOutboxEvent.id.eq(id))
+        .execute();
+  }
+
+  public void markSent(Long id, OutboxStatus status, LocalDateTime sentAt) {
+    new JPAUpdateClause(entityManager, memberOutboxEvent)
+        .set(memberOutboxEvent.status, status)
+        .set(memberOutboxEvent.sentAt, sentAt)
+        .set(memberOutboxEvent.updatedAt, sentAt)
+        .where(memberOutboxEvent.id.eq(id))
+        .execute();
+  }
+
+  public void markFailed(Long id, String errorMessage, LocalDateTime now, int maxRetry) {
+    var statusCase =
+        new CaseBuilder()
+            .when(memberOutboxEvent.retryCount.add(1).goe(maxRetry))
+            .then(Expressions.constant(OutboxStatus.FAILED))
+            .otherwise(Expressions.constant(OutboxStatus.PENDING));
+
+    new JPAUpdateClause(entityManager, memberOutboxEvent)
+        .set(memberOutboxEvent.lastErrorMessage, errorMessage)
+        .set(memberOutboxEvent.updatedAt, now)
+        .set(memberOutboxEvent.retryCount, memberOutboxEvent.retryCount.add(1))
+        .set(memberOutboxEvent.status, statusCase)
+        .where(memberOutboxEvent.id.eq(id))
+        .execute();
+  }
+}

--- a/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/MemberOutboxQueryRepository.java
+++ b/member-service/src/main/java/com/modeunsa/boundedcontext/member/out/persistence/outbox/MemberOutboxQueryRepository.java
@@ -1,0 +1,71 @@
+package com.modeunsa.boundedcontext.member.out.persistence.outbox;
+
+import static com.modeunsa.boundedcontext.member.domain.entity.QMemberOutboxEvent.memberOutboxEvent;
+import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
+
+import com.modeunsa.boundedcontext.member.domain.entity.MemberOutboxEvent;
+import com.modeunsa.global.kafka.outbox.OutboxStatus;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberOutboxQueryRepository {
+
+  public static final String LOCK_TIMEOUT = "jakarta.persistence.lock.timeout";
+  public static final int SKIP_LOCKED = -2;
+
+  private final JPAQueryFactory queryFactory;
+
+  // polling 주기를 고려하여, createdAt 기준으로 내림차순 정렬하여 가장 오래된 PENDING 이벤트부터 처리하도록 함
+  // PESSIMISTIC_WRITE 락과 SKIP_LOCKED 힌트를 사용하여 동시에 여러 인스턴스에서 실행되는 경우에도 중복 처리가 발생하지 않도록 함
+  public List<MemberOutboxEvent> findPendingEventsWithLock(Pageable pageable) {
+
+    BooleanBuilder where = new BooleanBuilder();
+    where.and(eqStatus(OutboxStatus.PENDING));
+
+    JPAQuery<MemberOutboxEvent> query =
+        this.queryFactory
+            .selectFrom(memberOutboxEvent)
+            .where(where)
+            .orderBy(memberOutboxEvent.createdAt.desc())
+            .setLockMode(PESSIMISTIC_WRITE)
+            .setHint(LOCK_TIMEOUT, SKIP_LOCKED)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+    return query.fetch();
+  }
+
+  public List<Long> findDeleteTargetIds(LocalDateTime before, Pageable pageable) {
+
+    JPAQuery<Long> contentQuery =
+        this.queryFactory
+            .select(memberOutboxEvent.id)
+            .from(memberOutboxEvent)
+            .where(
+                eqStatus(OutboxStatus.SENT),
+                memberOutboxEvent.sentAt.isNotNull(),
+                beforeSentAt(before))
+            .orderBy(memberOutboxEvent.sentAt.asc(), memberOutboxEvent.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+    return contentQuery.fetch();
+  }
+
+  private BooleanExpression eqStatus(OutboxStatus status) {
+    return status != null ? memberOutboxEvent.status.eq(status) : null;
+  }
+
+  private BooleanExpression beforeSentAt(LocalDateTime before) {
+    return before != null ? memberOutboxEvent.sentAt.before(before) : null;
+  }
+}

--- a/member-service/src/main/resources/application-test.yml
+++ b/member-service/src/main/resources/application-test.yml
@@ -36,3 +36,7 @@ settlement:
 
 internal:
   api-key: test-internal-key
+
+encryption:
+  enabled: false
+  master-key: test

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -129,7 +129,7 @@ app:
   simulation:
     enabled: true
   event-publisher:
-    type: ${EVENT_PUBLISHER_TYPE:kafka}
+    type: ${EVENT_PUBLISHER_TYPE:outbox}
   event-consumer:
     type: ${EVENT_CONSUMER_TYPE:kafka}
   data-init:
@@ -137,3 +137,16 @@ app:
 
 internal:
   api-key: ${INTERNAL_API_KEY}
+
+outbox:
+  enabled: true
+  timeoutMs: 10000
+  poller:
+    enabled: true
+    interval-ms: 5000
+    batch-size: 100
+    max-retry: 5
+    retention-days: 7
+  cleanup:
+    batch-size: 500
+    cron: "0 0 3 * * *"

--- a/member-service/src/test/java/com/modeunsa/boundedcontext/member/MemberOutboxIntegrationTest.java
+++ b/member-service/src/test/java/com/modeunsa/boundedcontext/member/MemberOutboxIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.modeunsa.boundedcontext.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.modeunsa.MemberApplication;
+import com.modeunsa.boundedcontext.member.app.outbox.MemberOutboxPoller;
+import com.modeunsa.global.eventpublisher.EventPublisher;
+import com.modeunsa.global.eventpublisher.topic.DomainEventEnvelope;
+import com.modeunsa.global.kafka.outbox.OutboxStatus;
+import com.modeunsa.shared.member.event.MemberSignupEvent;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(
+    classes = MemberApplication.class,
+    properties = {
+      "app.event-publisher.type=outbox",
+      "outbox.poller.enabled=true",
+      "spring.task.scheduling.enabled=false",
+      "app.data-init.enabled=false",
+    })
+@ActiveProfiles("test")
+@DisplayName("Member Outbox 통합 테스트")
+class MemberOutboxIntegrationTest {
+
+  @Autowired private EventPublisher eventPublisher;
+  @Autowired private MemberOutboxPoller memberOutboxPoller;
+  @Autowired private TransactionTemplate transactionTemplate;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @MockitoBean private KafkaTemplate<String, Object> kafkaTemplate;
+
+  @BeforeEach
+  void setUp() {
+    jdbcTemplate.update("delete from member_outbox_event");
+  }
+
+  @Test
+  @DisplayName("트랜잭션 커밋 시 outbox에 PENDING으로 저장되고, poller가 Kafka로 발행 후 SENT로 변경한다")
+  void commitSavesPendingEventAndPollerPublishesIt() {
+    when(kafkaTemplate.send(anyString(), anyString(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    transactionTemplate.executeWithoutResult(tx -> eventPublisher.publish(signupEvent()));
+
+    Map<String, Object> row =
+        jdbcTemplate.queryForMap(
+            "select aggregate_type, aggregate_id, event_type, topic, status"
+                + " from member_outbox_event");
+    assertThat(row.get("status")).isEqualTo(OutboxStatus.PENDING.name());
+    assertThat(row.get("topic")).isEqualTo("member-events");
+    assertThat(row.get("event_type")).isEqualTo("MemberSignupEvent");
+    assertThat(row.get("aggregate_type")).isEqualTo("Member");
+    assertThat(row.get("aggregate_id")).isEqualTo("member-1");
+
+    memberOutboxPoller.poll();
+
+    ArgumentCaptor<DomainEventEnvelope> envelopeCaptor =
+        ArgumentCaptor.forClass(DomainEventEnvelope.class);
+    verify(kafkaTemplate).send(eq("member-events"), eq("member-1"), envelopeCaptor.capture());
+
+    DomainEventEnvelope envelope = envelopeCaptor.getValue();
+    assertThat(envelope.eventType()).isEqualTo("MemberSignupEvent");
+    assertThat(envelope.topic()).isEqualTo("member-events");
+
+    Map<String, Object> sentRow =
+        jdbcTemplate.queryForMap("select status, sent_at from member_outbox_event");
+    assertThat(sentRow.get("status")).isEqualTo(OutboxStatus.SENT.name());
+    assertThat(sentRow.get("sent_at")).isNotNull();
+  }
+
+  @Test
+  @DisplayName("트랜잭션 롤백 시 outbox에 이벤트가 저장되지 않는다")
+  void rollbackDoesNotSaveOutboxEvent() {
+    transactionTemplate.executeWithoutResult(
+        tx -> {
+          eventPublisher.publish(signupEvent());
+          tx.setRollbackOnly();
+        });
+
+    Integer count =
+        jdbcTemplate.queryForObject("select count(*) from member_outbox_event", Integer.class);
+    assertThat(count).isZero();
+  }
+
+  private MemberSignupEvent signupEvent() {
+    return new MemberSignupEvent(1L, "홍길동", "test@modeunsa.com", "010-1234-5678", "USER", "ACTIVE");
+  }
+}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)

-->

## #⃣ 연관된 이슈

> close #589

## 📝 작업 내용

member-service의 이벤트 발행 경로에 트랜잭션 아웃박스 패턴을 적용합니다.

기존에는 `@Transactional` 안에서 Kafka로 직접 발행(dual-write)하여, DB 커밋 성공 후 Kafka 발행이 실패하면(브로커 장애 등) 이벤트가 유실될 수 있었습니다. 이번 변경으로 이벤트를 비즈니스 트랜잭션과 **같은 트랜잭션**으로 `member_outbox_event` 테이블에 저장하고, 폴러가 Kafka로 발행 후 SENT/FAILED 마킹합니다.

### How
- **payment-service의 기존 outbox 구현을 그대로 준용** (공통 인프라 `OutboxPublisher`/`OutboxPollerRunner`/`OutboxDomainEventPublisher` 재사용, settlement에서 운영 검증된 패턴)
- `MemberOutboxEvent` 엔티티 — `ddl-auto: update`로 테이블 자동 생성
- `MemberOutboxPublisher` — `@Transactional(MANDATORY)`: 발행이 반드시 비즈니스 트랜잭션에 참여하도록 강제 (모든 발행 지점이 UseCase 또는 MemberFacade의 `@Transactional` 안에 있음을 확인)
- `MemberOutboxPoller` — `@Scheduled` 5초 폴링 + 새벽 3시 오래된 SENT 이벤트 정리, `PESSIMISTIC_WRITE` + `SKIP_LOCKED`로 멀티 인스턴스 중복 처리 방지
- `application.yml` — `event-publisher.type` 기본값 `kafka` → `outbox` 전환 + `outbox:` 설정 블록 추가
- **payload 저장 시 암호화** — 회원 이벤트 payload에는 이름/전화번호 등 PII가 포함되므로, 엔티티 필드와 동일하게 `EncryptedStringConverter`(AES-GCM) 적용 (payment/settlement outbox와의 차이점)
- 와이어 포맷(`DomainEventEnvelope`, aggregateId 키)은 기존 Kafka 직접 발행과 동일 → 컨슈머 변경 불필요. eventId가 outbox 저장 시 한 번 생성되어 재발행 시에도 유지되므로 컨슈머 dedup에 유리

### Test
- 통합 테스트 `MemberOutboxIntegrationTest` 추가 (2건 통과)
  - 트랜잭션 커밋 → outbox PENDING 저장 → `poll()` → Kafka 발행(topic/key/envelope 검증) → SENT + sent_at 마킹
  - 트랜잭션 롤백 → outbox 미저장
- `./gradlew :member-service:build` 전체 통과 (spotless 포함)
- member 테스트 프로파일에 encryption 설정이 없어 `@SpringBootTest` 컨텍스트가 뜨지 않던 문제를 함께 수정 (`application-test.yml`에 settlement과 동일하게 `encryption.enabled: false` 추가 — 기존 테스트가 전부 `@Disabled`라 드러나지 않았음)

## 💬 리뷰 요구사항

- `event-publisher.type` 기본값 전환으로 **모든 환경(dev/k3s)에서 outbox가 활성화**됩니다. 단계적 롤아웃이 필요하면 env `EVENT_PUBLISHER_TYPE=kafka`로 되돌릴 수 있습니다.
- 후속 과제(공통 `OutboxPollerRunner` 개선, payment/settlement에도 공통 적용): 폴러가 PROCESSING 마킹 후 죽으면 해당 행이 영구 방치되는 케이스 — stale PROCESSING 행을 PENDING으로 되돌리는 reaper 필요. #757로 발행했습니다.